### PR TITLE
Add QC to foodon

### DIFF
--- a/.github/workflows/qc.yml
+++ b/.github/workflows/qc.yml
@@ -29,5 +29,5 @@ jobs:
       - name: Run ontology QC checks
         env:
           DEFAULT_BRANCH: master
-        run: cd src/ontology && make ROBOT_ENV='ROBOT_JAVA_ARGS=-Xmx6G' test IMP=false PAT=true
+        run: cd src/ontology && make ROBOT_ENV='ROBOT_JAVA_ARGS=-Xmx6G' foodon.owl IMP=false PAT=true -B
 

--- a/.github/workflows/qc.yml
+++ b/.github/workflows/qc.yml
@@ -1,0 +1,33 @@
+# Basic Ontology QC for Foodon
+
+name: CI
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "ontology_qc"
+  ontology_qc:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    container: obolibrary/odkfull:v1.4.3
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - name: Run ontology QC checks
+        env:
+          DEFAULT_BRANCH: master
+        run: cd src/ontology && make ROBOT_ENV='ROBOT_JAVA_ARGS=-Xmx6G' test IMP=false PAT=true
+


### PR DESCRIPTION
This adds some basic QC to foodon using a GitHub action. It ensures, currently, that the ontology is checked for OWL 2 profile violations and unsatisfiable classes.

@ddooley if you want to extend the QC, you can just add as many tests as you want to the makefile and add them to the `test` target. For example:

```
my_test:
	#.... some test

test: my_test
```
