### PR TITLE
Updating seafood taxons & deleting a deprecated term

### DIFF
--- a/src/ontology/foodon-idranges.owl
+++ b/src/ontology/foodon-idranges.owl
@@ -102,6 +102,14 @@ Datatype: idrange:13
     EquivalentTo: 
         xsd:integer[> 2400000 , <= 2599999]
 
+Datatype: idrange:14
+
+    Annotations: 
+        allocatedto: "Fungal parts (manual curation)"
+    
+    EquivalentTo: 
+        xsd:integer[> 2600000 , <= 2609999]
+
 Datatype: idrange:4
 
     Annotations: 

--- a/src/ontology/foodon-idranges.owl
+++ b/src/ontology/foodon-idranges.owl
@@ -94,6 +94,14 @@ Datatype: idrange:10
     EquivalentTo: 
         xsd:integer[> 2230000 , <= 2399999]
 
+Datatype: idrange:13
+
+    Annotations: 
+        allocatedto: "Fungal template (generated)"
+    
+    EquivalentTo: 
+        xsd:integer[> 2400000 , <= 2599999]
+
 Datatype: idrange:4
 
     Annotations: 

--- a/src/ontology/foodon-idranges.owl
+++ b/src/ontology/foodon-idranges.owl
@@ -39,7 +39,6 @@ Datatype: idrange:1
     
     EquivalentTo: 
         xsd:integer[>= 0 , <= 999999]
-
     
 Datatype: idrange:2
 
@@ -48,11 +47,6 @@ Datatype: idrange:2
     
     EquivalentTo: 
         xsd:integer[>= 1000000 , <= 1999999]
-    
-    
-Datatype: xsd:integer
-
-    
 
 Datatype: idrange:3
 
@@ -65,7 +59,7 @@ Datatype: idrange:3
 Datatype: idrange:11
 
     Annotations: 
-        allocatedto: "Animal and Seafood parts (manual curation)"
+        allocatedto: "Manually curated organism parts"
     
     EquivalentTo: 
         xsd:integer[> 2010000 , <= 2019999]
@@ -77,14 +71,6 @@ Datatype: idrange:9
     
     EquivalentTo: 
         xsd:integer[> 2020000 , <= 2199999]
-
-Datatype: idrange:12
-
-    Annotations: 
-        allocatedto: "Plant parts (manual curation)"
-    
-    EquivalentTo: 
-        xsd:integer[> 2200000 , <= 2229999]
 
 Datatype: idrange:10
 
@@ -101,14 +87,6 @@ Datatype: idrange:13
     
     EquivalentTo: 
         xsd:integer[> 2400000 , <= 2599999]
-
-Datatype: idrange:14
-
-    Annotations: 
-        allocatedto: "Fungal parts (manual curation)"
-    
-    EquivalentTo: 
-        xsd:integer[> 2600000 , <= 2609999]
 
 Datatype: idrange:4
 
@@ -133,8 +111,6 @@ Datatype: idrange:6
     
     EquivalentTo: 
         xsd:integer[> 3601000 , <= 3601999]
-    
-Datatype: rdf:PlainLiteral
 
 Datatype: idrange:7
 
@@ -143,8 +119,6 @@ Datatype: idrange:7
     
     EquivalentTo: 
         xsd:integer[> 3602000 , <= 3602999]
-    
-Datatype: rdf:PlainLiteral
     
 Datatype: idrange:8
 

--- a/src/ontology/imports/deprecation_import.ofn
+++ b/src/ontology/imports/deprecation_import.ofn
@@ -585,7 +585,6 @@ Declaration(Class(obo:FOODON_03411862))
 Declaration(Class(obo:FOODON_03411863))
 Declaration(Class(obo:FOODON_03411864))
 Declaration(Class(obo:FOODON_03411865))
-Declaration(Class(obo:FOODON_03411866))
 Declaration(Class(obo:FOODON_03411867))
 Declaration(Class(obo:FOODON_03411868))
 Declaration(Class(obo:FOODON_03411869))
@@ -5833,12 +5832,6 @@ AnnotationAssertion(owl:deprecated obo:FOODON_03411864 "true"^^xsd:boolean)
 AnnotationAssertion(obo:IAO_0100001 obo:FOODON_03411865 obo:NCBITaxon_195626)
 AnnotationAssertion(rdfs:label obo:FOODON_03411865 "obsolete: slender sole"@en)
 AnnotationAssertion(owl:deprecated obo:FOODON_03411865 "true"^^xsd:boolean)
-
-# Class: obo:FOODON_03411866 (obsolete: arrowtooth flounder)
-
-AnnotationAssertion(obo:IAO_0100001 obo:FOODON_03411866 obo:NCBITaxon_428034)
-AnnotationAssertion(rdfs:label obo:FOODON_03411866 "obsolete: arrowtooth flounder"@en)
-AnnotationAssertion(owl:deprecated obo:FOODON_03411866 "true"^^xsd:boolean)
 
 # Class: obo:FOODON_03411867 (obsolete: gray sole)
 
@@ -14317,8 +14310,8 @@ AnnotationAssertion(owl:deprecated obo:FOODON_03460131 "true"^^xsd:boolean)
 
 # Class: obo:FOODON_03460136 (obsolete: sugar or sugar syrup added)
 
-AnnotationAssertion(obo:IAO_0100001 obo:FOODON_03460136 "http://purl.obolibrary.org/obo/FOODON_03420271"@en)
 AnnotationAssertion(obo:IAO_0100001 obo:FOODON_03460136 "http://purl.obolibrary.org/obo/CHEBI_17992"^^xsd:anyURI)
+AnnotationAssertion(obo:IAO_0100001 obo:FOODON_03460136 "http://purl.obolibrary.org/obo/FOODON_03420271"@en)
 AnnotationAssertion(oboInOwl:hasDbXref obo:FOODON_03460136 langual:H0136)
 AnnotationAssertion(oboInOwl:hasSynonym obo:FOODON_03460136 "disaccharide added"@en)
 AnnotationAssertion(oboInOwl:hasSynonym obo:FOODON_03460136 "monosaccharide added"@en)

--- a/src/ontology/imports/ncbitaxon_import.owl
+++ b/src/ontology/imports/ncbitaxon_import.owl
@@ -241,6 +241,7 @@ Declaration(Class(obo:NCBITaxon_1156138))
 Declaration(Class(obo:NCBITaxon_115623))
 Declaration(Class(obo:NCBITaxon_115624))
 Declaration(Class(obo:NCBITaxon_115666))
+Declaration(Class(obo:NCBITaxon_1156757))
 Declaration(Class(obo:NCBITaxon_1156758))
 Declaration(Class(obo:NCBITaxon_115715))
 Declaration(Class(obo:NCBITaxon_115816))
@@ -2025,6 +2026,7 @@ Declaration(Class(obo:NCBITaxon_30483))
 Declaration(Class(obo:NCBITaxon_304850))
 Declaration(Class(obo:NCBITaxon_30493))
 Declaration(Class(obo:NCBITaxon_30496))
+Declaration(Class(obo:NCBITaxon_3049887))
 Declaration(Class(obo:NCBITaxon_3049903))
 Declaration(Class(obo:NCBITaxon_30501))
 Declaration(Class(obo:NCBITaxon_30511))
@@ -2240,6 +2242,7 @@ Declaration(Class(obo:NCBITaxon_323853))
 Declaration(Class(obo:NCBITaxon_323886))
 Declaration(Class(obo:NCBITaxon_3241545))
 Declaration(Class(obo:NCBITaxon_32443))
+Declaration(Class(obo:NCBITaxon_3244320))
 Declaration(Class(obo:NCBITaxon_32446))
 Declaration(Class(obo:NCBITaxon_3250))
 Declaration(Class(obo:NCBITaxon_3251))
@@ -2362,6 +2365,10 @@ Declaration(Class(obo:NCBITaxon_3360502))
 Declaration(Class(obo:NCBITaxon_3362))
 Declaration(Class(obo:NCBITaxon_336262))
 Declaration(Class(obo:NCBITaxon_3363))
+Declaration(Class(obo:NCBITaxon_3363395))
+Declaration(Class(obo:NCBITaxon_3363545))
+Declaration(Class(obo:NCBITaxon_3363546))
+Declaration(Class(obo:NCBITaxon_3363547))
 Declaration(Class(obo:NCBITaxon_33636))
 Declaration(Class(obo:NCBITaxon_33637))
 Declaration(Class(obo:NCBITaxon_3367))
@@ -6815,12 +6822,18 @@ AnnotationAssertion(oboInOwl:hasExactSynonym obo:NCBITaxon_115666 "African eggpl
 AnnotationAssertion(rdfs:label obo:NCBITaxon_115666 "Solanum macrocarpon")
 SubClassOf(obo:NCBITaxon_115666 obo:NCBITaxon_4107)
 
+# Class: obo:NCBITaxon_1156757 (Colistium)
+
+AnnotationAssertion(obo:IAO_0000412 obo:NCBITaxon_1156757 obo:ncbitaxon.owl)
+AnnotationAssertion(rdfs:label obo:NCBITaxon_1156757 "Colistium")
+SubClassOf(obo:NCBITaxon_1156757 obo:NCBITaxon_490374)
+
 # Class: obo:NCBITaxon_1156758 (Colistium nudipinnis)
 
 AnnotationAssertion(obo:IAO_0000412 obo:NCBITaxon_1156758 obo:ncbitaxon.owl)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:NCBITaxon_1156758 "New Zealand turbot")
 AnnotationAssertion(rdfs:label obo:NCBITaxon_1156758 "Colistium nudipinnis")
-SubClassOf(obo:NCBITaxon_1156758 obo:NCBITaxon_490374)
+SubClassOf(obo:NCBITaxon_1156758 obo:NCBITaxon_1156757)
 
 # Class: obo:NCBITaxon_115715 (Vigna subterranea)
 
@@ -18840,6 +18853,12 @@ AnnotationAssertion(obo:IAO_0000412 obo:NCBITaxon_30496 obo:ncbitaxon.owl)
 AnnotationAssertion(rdfs:label obo:NCBITaxon_30496 "Lamniformes")
 SubClassOf(obo:NCBITaxon_30496 obo:NCBITaxon_119195)
 
+# Class: obo:NCBITaxon_3049887 (Colistium guentheri)
+
+AnnotationAssertion(obo:IAO_0000412 obo:NCBITaxon_3049887 obo:ncbitaxon.owl)
+AnnotationAssertion(rdfs:label obo:NCBITaxon_3049887 "Colistium guentheri")
+SubClassOf(obo:NCBITaxon_3049887 obo:NCBITaxon_1156757)
+
 # Class: obo:NCBITaxon_3049903 (Scyris alexandrina)
 
 AnnotationAssertion(obo:IAO_0000412 obo:NCBITaxon_3049903 obo:ncbitaxon.owl)
@@ -20312,6 +20331,13 @@ AnnotationAssertion(oboInOwl:hasExactSynonym obo:NCBITaxon_32443 "teleost fishes
 AnnotationAssertion(rdfs:label obo:NCBITaxon_32443 "Teleostei")
 SubClassOf(obo:NCBITaxon_32443 obo:NCBITaxon_41665)
 
+# Class: obo:NCBITaxon_3244320 (Lamarcka imbricata)
+
+AnnotationAssertion(obo:IAO_0000412 obo:NCBITaxon_3244320 obo:ncbitaxon.owl)
+AnnotationAssertion(oboInOwl:hasExactSynonym obo:NCBITaxon_3244320 "mossy ark")
+AnnotationAssertion(rdfs:label obo:NCBITaxon_3244320 "Lamarcka imbricata")
+SubClassOf(obo:NCBITaxon_3244320 obo:NCBITaxon_6553)
+
 # Class: obo:NCBITaxon_32446 (Clupeiformes)
 
 AnnotationAssertion(obo:IAO_0000412 obo:NCBITaxon_32446 obo:ncbitaxon.owl)
@@ -21154,6 +21180,33 @@ SubClassOf(obo:NCBITaxon_336262 obo:NCBITaxon_224712)
 AnnotationAssertion(obo:IAO_0000412 obo:NCBITaxon_3363 obo:ncbitaxon.owl)
 AnnotationAssertion(rdfs:label obo:NCBITaxon_3363 "Podocarpus")
 SubClassOf(obo:NCBITaxon_3363 obo:NCBITaxon_3362)
+
+# Class: obo:NCBITaxon_3363395 (Caliraja)
+
+AnnotationAssertion(obo:IAO_0000412 obo:NCBITaxon_3363395 obo:ncbitaxon.owl)
+AnnotationAssertion(rdfs:label obo:NCBITaxon_3363395 "Caliraja")
+SubClassOf(obo:NCBITaxon_3363395 obo:NCBITaxon_30475)
+
+# Class: obo:NCBITaxon_3363545 (Caliraja inornata)
+
+AnnotationAssertion(obo:IAO_0000412 obo:NCBITaxon_3363545 obo:ncbitaxon.owl)
+AnnotationAssertion(oboInOwl:hasExactSynonym obo:NCBITaxon_3363545 "California ray")
+AnnotationAssertion(rdfs:label obo:NCBITaxon_3363545 "Caliraja inornata")
+SubClassOf(obo:NCBITaxon_3363545 obo:NCBITaxon_3363395)
+
+# Class: obo:NCBITaxon_3363546 (Caliraja rhina)
+
+AnnotationAssertion(obo:IAO_0000412 obo:NCBITaxon_3363546 obo:ncbitaxon.owl)
+AnnotationAssertion(oboInOwl:hasExactSynonym obo:NCBITaxon_3363546 "longnose skate")
+AnnotationAssertion(rdfs:label obo:NCBITaxon_3363546 "Caliraja rhina")
+SubClassOf(obo:NCBITaxon_3363546 obo:NCBITaxon_3363395)
+
+# Class: obo:NCBITaxon_3363547 (Caliraja stellulata)
+
+AnnotationAssertion(obo:IAO_0000412 obo:NCBITaxon_3363547 obo:ncbitaxon.owl)
+AnnotationAssertion(oboInOwl:hasExactSynonym obo:NCBITaxon_3363547 "starry skate")
+AnnotationAssertion(rdfs:label obo:NCBITaxon_3363547 "Caliraja stellulata")
+SubClassOf(obo:NCBITaxon_3363547 obo:NCBITaxon_3363395)
 
 # Class: obo:NCBITaxon_33636 (Laminariaceae)
 

--- a/src/ontology/imports/ncbitaxon_ontofox.txt
+++ b/src/ontology/imports/ncbitaxon_ontofox.txt
@@ -11,6 +11,14 @@ NCBITaxon
 # NEED Smilax aristolochiifolia / Mexican sasparilla
 # NEED Mitragyna javanica
 
+
+#DELETED NCBITaxon_1913631 # Colistium guntheri
+http://purl.obolibrary.org/obo/NCBITaxon_3049887 # Colistium guentheri
+
+# DELETED NCBITaxon_121025 # Arca imbricata
+http://purl.obolibrary.org/obo/NCBITaxon_3244320 # Lamarcka imbricata
+
+
 # DELETED NCBITaxon_492052 # Clitocybe nuda
 http://purl.obolibrary.org/obo/NCBITaxon_64659 # Collybia nuda
 
@@ -30,7 +38,9 @@ http://purl.obolibrary.org/obo/NCBITaxon_1260532 # Micropogonias megalops Donkey
 http://purl.obolibrary.org/obo/NCBITaxon_223891 # Solanum virginianum
 
 # DELETED NCBITaxon_30478 # Raja rhina
-http://purl.obolibrary.org/obo/NCBITaxon_2838338 # Beringraja rhina (Synonym: Raja rhina, Alternative ID->NCBITaxon_30478)
+# DELETED NCBITaxon_2838338 # Beringraja rhina (Synonym: Raja rhina, Alternative ID->NCBITaxon_30478)
+http://purl.obolibrary.org/obo/NCBITaxon_3363546 # Caliraja rhina
+
 
 # DELETED NCBITaxon_218804 # Leiognathus equulus
 http://purl.obolibrary.org/obo/NCBITaxon_2893490 # Leiognathus equula (Alternative ID-> NCBITaxon_218804)
@@ -47,7 +57,8 @@ http://purl.obolibrary.org/obo/NCBITaxon_2838337 # Beringraja binoculata ( Synon
 http://purl.obolibrary.org/obo/NCBITaxon_2838341 # Phanerodon vaccai (Synonym: Rhacochilus vacca, Alternative ID->NCBITaxon_50905)
 
 # DELETED NCBITaxon_740706 # Raja inornata
-http://purl.obolibrary.org/obo/NCBITaxon_2838339 # Beringraja inornata (synonym: Raja inornata, Alternative ID->NCBITaxon_740706)
+# DELETED NCBITaxon_2838339 # Beringraja inornata (synonym: Raja inornata, Alternative ID->NCBITaxon_740706)
+http://purl.obolibrary.org/obo/NCBITaxon_3363545 # Caliraja inornata
 
 # DELETED NCBITaxon_114055 # Chlorella / Chlorella <Trebouxiophyceae incertae sedis>
 http://purl.obolibrary.org/obo/NCBITaxon_3071 # Chlorella
@@ -85,8 +96,9 @@ http://purl.obolibrary.org/obo/NCBITaxon_76927 # Nemadactylus bergi
 #DELETED NCBITaxon_75034 # Pomatomus saltatrix FDA Seafood
 http://purl.obolibrary.org/obo/NCBITaxon_94948 # Pomatomus saltator
 
-#DELETED NCBITaxon_740707 # Raja stellulata FDA Seafood
-http://purl.obolibrary.org/obo/NCBITaxon_2838340 # Beringraja stellulata
+# DELETED NCBITaxon_740707 # Raja stellulata FDA Seafood
+# DELETED NCBITaxon_2838340 # Beringraja stellulata
+http://purl.obolibrary.org/obo/NCBITaxon_3363547 # Caliraja stellulata
 
 #DELETED NCBITaxon_6786 # Cryptodromiopsis antillensis (Stimpson, 1858)
 # Reintroduced FoodOn term
@@ -400,7 +412,6 @@ http://purl.obolibrary.org/obo/NCBITaxon_1204434 # species:Brassica ruvo L. H. B
 http://purl.obolibrary.org/obo/NCBITaxon_1204718 # family:Lateolabracidae Springer and Raasch, 1995
 http://purl.obolibrary.org/obo/NCBITaxon_1206913 # species:Bembrops anatirostris Ginsburg, 1955
 http://purl.obolibrary.org/obo/NCBITaxon_1206914 # species:Bembrops gobioides (Goode, 1880)
-http://purl.obolibrary.org/obo/NCBITaxon_121025 # Arca imbricata
 http://purl.obolibrary.org/obo/NCBITaxon_121046 # Leccinum aurantiacum
 http://purl.obolibrary.org/obo/NCBITaxon_121051 # Leccinum scabrum
 http://purl.obolibrary.org/obo/NCBITaxon_121072 # genus:Cassytha L.
@@ -1028,7 +1039,6 @@ http://purl.obolibrary.org/obo/NCBITaxon_1906136 # Barbonymus schwanenfeldii
 http://purl.obolibrary.org/obo/NCBITaxon_190902 # species:Mentha aquatica L.
 http://purl.obolibrary.org/obo/NCBITaxon_191066 # species:Empetrum nigrum L.
 http://purl.obolibrary.org/obo/NCBITaxon_1910901 # Lutjanus goreensis
-http://purl.obolibrary.org/obo/NCBITaxon_1913631 # Colistium guntheri
 http://purl.obolibrary.org/obo/NCBITaxon_191678 # species:Lophius budegassa Spinola, 1807
 http://purl.obolibrary.org/obo/NCBITaxon_1916796 # Channomuraena vittata
 http://purl.obolibrary.org/obo/NCBITaxon_191812 # genus:Somniosus Lesueur, 1818


### PR DESCRIPTION
1) Updated several seafood taxons: removed the old ones and added new ones. Some outdated IDs were still present in OntoFox but missing from the import file.
2) Just a test case: Removed a deprecated term to reuse its ID in the seafood template. If it works, the same could be done for a few other deprecated  seafood species as well.